### PR TITLE
Check if DataPackage.json should be loaded into Metadata

### DIFF
--- a/dist/backend/github.js
+++ b/dist/backend/github.js
@@ -125,7 +125,8 @@ class GitHubStorage extends _storageBackend.StorageBackend {
         metadata,
         message,
         branch,
-        readMe
+        readMe,
+        loadPkgJson
       } = options;
 
       if (!objectId) {
@@ -141,7 +142,7 @@ class GitHubStorage extends _storageBackend.StorageBackend {
       let newMetadata;
       let author;
       message = message || DEFAULT_COMMIT_MESSAGE;
-      (0, _githubApiHelper.getRepo)(objectId, branch, org, this.token).then(async repo => {
+      (0, _githubApiHelper.getRepo)(objectId, branch, org, this.token, loadPkgJson).then(async repo => {
         existingMetadata = repo.metadata;
         newMetadata = { ...existingMetadata,
           ...metadata

--- a/dist/backend/githubApiHelper.js
+++ b/dist/backend/githubApiHelper.js
@@ -267,7 +267,7 @@ async function deleteFile(repoName, org, path, branch = 'main', octo, repo) {
   });
 }
 
-async function getRepo(objectId, branch, org, token) {
+async function getRepo(objectId, branch, org, token, loadPkgJson) {
   return new Promise(async (resolve, reject) => {
     const owner = org;
     branch = branch || 'main';
@@ -358,10 +358,14 @@ async function getRepo(objectId, branch, org, token) {
         if (entry.name == 'datapackage.json') {
           let metadata = entry.object.text;
 
-          try {
-            metadata = JSON.parse(metadata);
-          } catch (error) {
-            reject(error);
+          if (!typeof loadPkgJson) {
+            try {
+              metadata = JSON.parse(metadata);
+            } catch (error) {
+              reject(error);
+            }
+          } else {
+            metadata = {};
           }
 
           repoInfo["metadata"] = metadata;

--- a/src/backend/github.js
+++ b/src/backend/github.js
@@ -148,10 +148,11 @@ class GitHubStorage extends StorageBackend {
    *            message: commit message for files commited to the repo on github,
    *            branch: main or master, branch on github to look for content
    *            readMe: A markdown flavored text of the repository's README}
+   *            loadPkgJson: determine if datapackage.json should be loaded into metadata
    */
   async update(options = {}) {
     return new Promise(async (resolve, reject) => {
-      let { objectId, metadata, message, branch, readMe } = options
+      let { objectId, metadata, message, branch, readMe, loadPkgJson } = options
 
       if (!objectId) {
         throw new Error('objectId name cannot be null')
@@ -164,7 +165,7 @@ class GitHubStorage extends StorageBackend {
 
       message = message || DEFAULT_COMMIT_MESSAGE
 
-      getRepo(objectId, branch, org, this.token)
+      getRepo(objectId, branch, org, this.token, loadPkgJson)
         .then(async (repo) => {
           existingMetadata = repo.metadata
           newMetadata = { ...existingMetadata, ...metadata }

--- a/src/backend/githubApiHelper.js
+++ b/src/backend/githubApiHelper.js
@@ -376,8 +376,9 @@ async function deleteFile(repoName, org, path, branch='main', octo, repo){
  * @param {*} branch
  * @param {*} org
  * @param {*} token
+ * @param {*} loadPkgJson
  */
-async function getRepo(objectId, branch, org, token) {
+async function getRepo(objectId, branch, org, token, loadPkgJson) {
   return new Promise(async (resolve, reject) => {
     const owner = org
     branch = branch || 'main'
@@ -472,11 +473,16 @@ async function getRepo(objectId, branch, org, token) {
           }
           if (entry.name == 'datapackage.json') {
             let metadata = entry.object.text
-            try {
-              metadata = JSON.parse(metadata)
-            } catch (error) {
-              reject(error)
+            if( !typeof(loadPkgJson)) {
+              try {
+                metadata = JSON.parse(metadata)
+              } catch (error) {
+                reject(error)
+              }
+            } else {
+              metadata = {}
             }
+            
             repoInfo["metadata"] = metadata
           }
 


### PR DESCRIPTION
This PR adds a conditional argument to decide if datapackage.json should be added to the metadata or not, before updating the metadata, base on the uploaded resource. This is done due to the error encountered in `gift-portal` while loading `datapackage.json` from `github`.